### PR TITLE
Add step for generating log summary file at end of GO-CAM processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ auto-save-list
 tramp
 .\#*
 
+## Other IDEs
+.idea
+.vscode
+
 ## Org-mode
 .org-id-locations
 *_archive

--- a/scripts/gocam-processing.sh
+++ b/scripts/gocam-processing.sh
@@ -58,22 +58,25 @@ su jenkins -c 'wget -q -O /tmp/gocam-work/go.obo https://current.geneontology.or
 su jenkins -c 'wget -q -O /tmp/gocam-work/groups.yaml https://current.geneontology.org/metadata/groups.yaml'
 
 # Step 1: Convert Minerva models to GO-CAM models.
-su jenkins -c 'uv run python pipeline/convert_minerva_models_to_gocam_models.py --input-dir /tmp/gocam-work/input --output-dir /tmp/gocam-work/01-gocam-models --report-file /tmp/gocam-work/reports/01-convert.json --verbose'
+su jenkins -c 'uv run python pipeline/convert_minerva_models_to_gocam_models.py --input-dir /tmp/gocam-work/input --output-dir /tmp/gocam-work/01-gocam-models --report-file /tmp/gocam-work/reports/01-convert.jsonl --verbose'
 
 # Step 2: Filter true GO-CAM models from pseudo GO-CAMs.
-su jenkins -c 'uv run python pipeline/filter_true_gocam_models.py --input-dir /tmp/gocam-work/01-gocam-models --output-dir /tmp/gocam-work/02-true-gocams --pseudo-gocam-output-dir /tmp/gocam-work/02-pseudo-gocams --report-file /tmp/gocam-work/reports/02-filter.json --verbose'
+su jenkins -c 'uv run python pipeline/filter_true_gocam_models.py --input-dir /tmp/gocam-work/01-gocam-models --output-dir /tmp/gocam-work/02-true-gocams --pseudo-gocam-output-dir /tmp/gocam-work/02-pseudo-gocams --report-file /tmp/gocam-work/reports/02-filter.jsonl --verbose'
 
 # Step 3: Add query index (OAK lookups) to models.
 # Uses released GO ontology via pronto adapter.
 # NCBITaxon is not a GO product, so it still auto-downloads from
 # OBO Foundry (sqlite:obo:ncbitaxon).
-su jenkins -c 'uv run python pipeline/add_query_index_to_models.py --input-dir /tmp/gocam-work/02-true-gocams --output-dir /tmp/gocam-work/03-indexed-true-gocams --report-file /tmp/gocam-work/reports/03-index.json --go-adapter-descriptor pronto:/tmp/gocam-work/go.obo --goc-groups-yaml /tmp/gocam-work/groups.yaml --verbose'
+su jenkins -c 'uv run python pipeline/add_query_index_to_models.py --input-dir /tmp/gocam-work/02-true-gocams --output-dir /tmp/gocam-work/03-indexed-true-gocams --report-file /tmp/gocam-work/reports/03-index.jsonl --go-adapter-descriptor pronto:/tmp/gocam-work/go.obo --goc-groups-yaml /tmp/gocam-work/groups.yaml --verbose'
 
 # Step 4: Generate index files (~6 JSON files).
-su jenkins -c 'uv run python pipeline/generate_index_files.py --input-dir /tmp/gocam-work/03-indexed-true-gocams --output-dir /tmp/gocam-work/04-index-files --report-file /tmp/gocam-work/reports/04-index-files.json --verbose'
+su jenkins -c 'uv run python pipeline/generate_index_files.py --input-dir /tmp/gocam-work/03-indexed-true-gocams --output-dir /tmp/gocam-work/04-index-files --report-file /tmp/gocam-work/reports/04-index-files.jsonl --verbose'
 
 # Step 5: Generate GO-CAM Browser search docs (1 JSON file).
-su jenkins -c 'uv run python pipeline/generate_go_cam_browser_search_docs.py --input-dir /tmp/gocam-work/03-indexed-true-gocams --output /tmp/gocam-work/05-browser-search-docs/go-cam-browser-search-docs.json --report-file /tmp/gocam-work/reports/05-browser-search.json --verbose'
+su jenkins -c 'uv run python pipeline/generate_go_cam_browser_search_docs.py --input-dir /tmp/gocam-work/03-indexed-true-gocams --output /tmp/gocam-work/05-browser-search-docs/go-cam-browser-search-docs.json --report-file /tmp/gocam-work/reports/05-browser-search.jsonl --verbose'
+
+# Lastly: Generate summary report (1 Excel file).
+su jenkins -c 'uv run python pipeline/generate_log_summary.py --logs-dir /tmp/gocam-work/reports --output /tmp/gocam-work/reports/summary.xlsx --verbose'
 
 # Helper for retried scp.
 scp_retry() {


### PR DESCRIPTION
These changes add a call to the `generate_log_summary.py` script (introduced in https://github.com/geneontology/gocam-py/pull/193) at the end of the GO-CAM processing work. This script consolidates information from the JSONL log files produced by the preceding steps into one Excel file.

Incidentally I also changed the file extension of existing log files from `.json` to `.jsonl` (a) to more accurately represent their contents and (b) because that's the file extension that `generate_log_summary.py` looks for by default.