### PR TITLE
Populate release date and pipeline branch in GO-CAM summary report

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -478,6 +478,8 @@ pipeline {
 			      -e JENKINS_UID="\$JENKINS_UID" \\
 			      -e JENKINS_GID="\$JENKINS_GID" \\
 			      -e MINERVA_JSON_TARBALL_URL="\$MINERVA_JSON_TARBALL_URL" \\
+			      -e START_DATE="\$START_DATE" \\
+			      -e BRANCH_NAME="\$BRANCH_NAME" \\
 			      ubuntu:noble \\
 			      bash /workspace/scripts/gocam-processing.sh
 			"""

--- a/scripts/gocam-processing.sh
+++ b/scripts/gocam-processing.sh
@@ -76,7 +76,7 @@ su jenkins -c 'uv run python pipeline/generate_index_files.py --input-dir /tmp/g
 su jenkins -c 'uv run python pipeline/generate_go_cam_browser_search_docs.py --input-dir /tmp/gocam-work/03-indexed-true-gocams --output /tmp/gocam-work/05-browser-search-docs/go-cam-browser-search-docs.json --report-file /tmp/gocam-work/reports/05-browser-search.jsonl --verbose'
 
 # Lastly: Generate summary report (1 Excel file).
-su jenkins -c "uv run python pipeline/generate_log_summary.py --logs-dir /tmp/gocam-work/reports --output /tmp/gocam-work/reports/summary.xlsx --metadata 'Release date=${START_DATE}' --metadata 'Pipeline branch=${BRANCH_NAME}' --verbose"
+su jenkins -c "uv run python pipeline/generate_log_summary.py --logs-dir /tmp/gocam-work/reports --output /tmp/gocam-work/reports/summary.xlsx --metadata 'Release date=${START_DATE}' --metadata 'Pipeline name=pipeline-from-goa' --metadata 'Pipeline branch=${BRANCH_NAME}' --verbose"
 
 # Helper for retried scp.
 scp_retry() {

--- a/scripts/gocam-processing.sh
+++ b/scripts/gocam-processing.sh
@@ -76,7 +76,7 @@ su jenkins -c 'uv run python pipeline/generate_index_files.py --input-dir /tmp/g
 su jenkins -c 'uv run python pipeline/generate_go_cam_browser_search_docs.py --input-dir /tmp/gocam-work/03-indexed-true-gocams --output /tmp/gocam-work/05-browser-search-docs/go-cam-browser-search-docs.json --report-file /tmp/gocam-work/reports/05-browser-search.jsonl --verbose'
 
 # Lastly: Generate summary report (1 Excel file).
-su jenkins -c 'uv run python pipeline/generate_log_summary.py --logs-dir /tmp/gocam-work/reports --output /tmp/gocam-work/reports/summary.xlsx --verbose'
+su jenkins -c "uv run python pipeline/generate_log_summary.py --logs-dir /tmp/gocam-work/reports --output /tmp/gocam-work/reports/summary.xlsx --metadata 'Release date=${START_DATE}' --metadata 'Pipeline branch=${BRANCH_NAME}' --verbose"
 
 # Helper for retried scp.
 scp_retry() {


### PR DESCRIPTION
These changes use functionality added in https://github.com/geneontology/gocam-py/pull/200, which allows the caller of `generate_log_summary.py` to inject information that will end up in the report's metadata worksheet. In this case I'm injecting the "release date" (which I recognize is not a stable, official release while this pipeline is in development), pipeline name (hardcoded to `pipeline-from-goa`), and the pipeline branch name.