### PR TITLE
docs(operations-handoff): track downstream consumer updates (downloads / go-cam-browser / go-stats / npm)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,17 @@ Facts that shape the work (so they aren't relearned):
   / CloudFront `E3Q4YIZHZL7358`; release = `go-data-product-release` /
   `E2HF1DWYYDLTQP`. (Canonical bucket↔distribution table lives in
   `geneontology/operations` `CLAUDE.md`.)
-- **Deploys read from `current`, not skyhook.** The `operations` ansible
+- **`current` is the canonical source of truth post-release — for *all*
+  public links and downstream consumers, not just deploys.** Point
+  consumers at `current.geneontology.org`, never the rolling skyhook build
+  or EBI upstream (the downloads-page links and the go-cam-browser
+  `public/data.json` were repointed to `current` for exactly this reason,
+  2026-06-19). Deploys are the canonical case: the `operations` ansible
   (`update-golr.yaml`, `amigo-golr-up-production.yml`) pulls input over
   HTTP from `current.geneontology.org/products/...`, so publishing to
   `go-data-product-current` is what unblocks golr/amigo deploy. Those
-  steps stay in `operations`, not this pipeline (but track them).
+  steps stay in `operations`, not this pipeline (but track them). (This is
+  the consumer-side complement to the input-side Data-provenance rule below.)
 - **Out of scope / legacy:** `rdf.geneontology.org` / production
   Blazegraph journal / graphstore rebuild are being decommissioned — no
   outward-facing concern. Do **not** add Blazegraph product generation.
@@ -51,9 +57,13 @@ Facts that shape the work (so they aren't relearned):
   (`directory_indexer.py`, `s3-uploader.py`, `bucket-indexer.py`,
   `zenodo-version-update.py`) — don't reinvent it. The **downloads page is
   not ours**: it is generated in `geneontology.github.io`
-  (`scripts/update_downloads.py`, driven only by go-site `metadata/goex.yaml`),
-  tracked at pipeline#396 — do not add a downloads-page generator here. (The
-  go-site `downloads-page-gen.py` is superseded.)
+  (`scripts/update_downloads.py`, driven only by go-site `metadata/goex.yaml`)
+  — do not add a downloads-page generator here (the go-site
+  `downloads-page-gen.py` is superseded). As of gh.io#930 it is served
+  **in-site** at `geneontology.org/docs/download-go-annotations/downloads`
+  (links to `current`); the old
+  `current.geneontology.org/products/pages/downloads.html` becomes a
+  CloudFront-Function redirect (operations#86). Follow-ups: #396, gh.io#931.
 
 ## Data provenance
 

--- a/docs/operations-handoff.md
+++ b/docs/operations-handoff.md
@@ -54,8 +54,19 @@ curl -s   http://current.geneontology.org/products/solr/golr_timestamp.log      
 curl -s   http://current.geneontology.org/metadata/release-archive-doi.json        # expect doi 10.5281/zenodo.20943148
 ```
 
-## Out of scope for this hand-off (separate / human)
+## Downstream consumer updates (track these — not "out of scope")
 
-- go-cam-browser data release (regenerate + commit `public/data.json` — "ping Patrick")
-- amigo / metadata npm publishes
-- downloads page (`geneontology.github.io`, driven from the pipeline session — see #396)
+The golr/amigo/api deploy above is the operations-owned core, but the release is
+not done until the downstream consumer surfaces reflect it too. These live in
+other repos / with other people, but they belong on the release board (see
+`release-runbook.md` "Definition of done") — listed here so the operations
+session sees the whole board, not just golr/amigo/api.
+
+| Surface | Action this release | Owner | Tracking |
+| --- | --- | --- | --- |
+| **go-stats / `stats.html`** | **None.** `release_stats/` (the go-stats output, e.g. `go-stats-summary.json` carrying the `release_date`, and `aggregated-go-stats-summaries.json`) is generated **in the pipeline** (Phase 2) and published with the tree; `geneontology.org/stats.html` fetches `release_stats/` dynamically. Supersedes the old SNS-triggered post-publish go-stats step — no separate action. | pipeline | — |
+| **Downloads page** | Regenerate / repoint the by-organism annotation downloads to `current`; now served **in-site** at `geneontology.org/docs/download-go-annotations/downloads/` (links use the new `annotations/gaf/`·`gpi/` layout). | `geneontology.github.io` | #396, gh.io#930 |
+| **Downloads old-URL forward** | CloudFront **Function** 301 `/products/pages/downloads.html` → the in-site page. Associate **after** gh.io#930 deploys, else it 301s to a 404. | **operations** | operations#86 |
+| **go-cam-browser data** | Regenerate + commit `public/data.json` (`data-release-YYYY-MM-DD` branch → merge → Pages auto-deploy). "ping Patrick". | `go-cam-browser` | per-release |
+| **npm packages** | `amigo` / metadata / `dbxrefs` — **only if their content changed** this release; not automatic per data release. | software | conditional |
+| **Release notes / announcement** | Only when there is a change or error. | human | — |

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -413,7 +413,10 @@ Picking up the new *release* (distinct from the annotations grace mechanism):
 - golr/AmiGO deploy from `current/products/solr` + the DOI → operations#82 T+24h
   verify. 🔧
 - GO API **restart** (re-fetches `index-json`); repoint only if #12 lands. 🔧
-- go-stats auto-fires on `current/metadata/release-date.json` change (SNS). 🟡
+- go-stats: **no separate step** — `release_stats/` is generated in-pipeline
+  (Phase 2) and published with the tree; `stats.html` reads it dynamically (the
+  `release_date` flows through `go-stats-summary.json`). Supersedes the old
+  SNS-triggered post-publish go-stats. ✅
 - go-cam-browser regenerate + commit `public/data.json` ("ping patrick"). 👤
 - Downloads page regenerate / switch to new layout (#396). 👤
 - amigo / metadata **npm** packages. 👤

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -45,8 +45,8 @@ the phases below, not done-criteria.
      `go-data-product-release`, dated).
 2. **Downloads page regenerated and deployed to the main website.** This is a
    `geneontology.github.io` step (`scripts/update_downloads.py`, driven only by
-   go-site `metadata/goex.yaml`, linking to skyhook annotations), tracked at
-   **pipeline#396** — **not** a pipeline-from-goa product. Currently manual
+   go-site `metadata/goex.yaml`, now served in-site linking to `current`
+   annotations — gh.io#930), tracked at **pipeline#396** — **not** a pipeline-from-goa product. Currently manual
    ("does not yet auto-regenerate").
 3. **Data products for external interfaces are in place, and any necessary
    service updates/restarts are done** for:
@@ -201,11 +201,14 @@ ever *read* the original.
   DOI minted **first** so it can be referenced elsewhere. Validated end-to-end on
   the Zenodo **sandbox** (the real 10.70 GiB golr tarball through the actual
   script + a 12 GiB synthetic PUT, byte-exact commits); production is an explicit
-  `--production` opt-in. **GATING before the first real mint:** rehearse with
+  `--production` opt-in. **Proven flow (2026-06-19):** rehearse with
   `--production --no-publish` for **both** concepts (`just zenodo-rehearse-main` /
   `zenodo-rehearse-products`), review the unpublished drafts in the Zenodo UI, then
-  discard them — this is the only part that **cannot** be sandbox-tested (legacy-origin
-  concept metadata). Full procedure + checklist: **docs/zenodo-archival.md**. 🟡
+  **publish the reviewed drafts** with `just zenodo-publish-draft-{main,products} <id>`
+  (typed-`PUBLISH` gate) — do **not** discard a good draft and re-upload, and do **not**
+  one-shot `zenodo-mint-*` ungated. The rehearsal is the only part that **cannot** be
+  sandbox-tested (legacy-origin concept metadata). Full procedure + checklist:
+  **docs/zenodo-archival.md**. 🟡
 - Write `metadata/release-archive-doi.json` (the uploader's `--output`, shape
   `{"doi": ...}`) back into the tree (it travels *in* the published products). 🟡
 - BDBag remote-file manifest — optional, was in old Archive. 🔨(optional)
@@ -304,15 +307,16 @@ Details / dependencies:
   internally with Minerva — not the pipeline's concern.)
 
 ## Phase 7 — Downstream app releases *(external / human)*
-- Downloads page: regenerate `downloads.html` in `geneontology.github.io` via
-  `scripts/update_downloads.py` (reads go-site `metadata/goex.yaml`, links to
-  skyhook annotations) → deploy via the website. Tracked at **pipeline#396**;
-  currently manual. **Stale-link bug:** the script's GAF links predate the #15
-  annotations restructure (`annotations/{code}.gaf.gz` /`{code}-uniprot.gaf.gz`)
-  and must move to `annotations/gaf/{code}-mod.gaf.gz` (~23 MOD orgs only) and
-  `annotations/gaf/{code}-uniprot.gaf.gz`; GPI currently links to EBI, not skyhook. 👤
-- go-cam-browser "ping patrick": regenerate committed `public/data.json` →
-  `data-release-YYYY-MM-DD` branch → merge → GitHub Pages auto-deploy. 👤
+- Downloads page (`geneontology.github.io` `scripts/update_downloads.py`,
+  goex.yaml-driven). **Done for 2026-06-19 (gh.io#930):** now served **in-site** at
+  `geneontology.org/docs/download-go-annotations/downloads`, links repointed to
+  `current` `annotations/gaf/{code}-{uniprot,mod}.gaf.gz` + `gpi/` (was the skyhook/EBI
+  flat-path stale-link bug, now fixed); old `products/pages/downloads.html` → CloudFront
+  redirect (operations#86). Remaining: build-wiring + retire old path (gh.io#931). 👤
+- go-cam-browser "ping patrick": refresh committed `public/data.json` from the canonical
+  product `current.geneontology.org/products/go-cam-search/go-cam-browser-search-docs.json`
+  (drop-in superset) → `data-release-YYYY-MM-DD` branch → merge → Pages. Done for
+  2026-06-19 (go-cam-browser#71); on-release automation tracked at go-cam-browser#72. 👤
 - amigo / metadata **npm** packages. 👤
 - Confirm GO API product switch. 👤
 
@@ -332,6 +336,14 @@ bless, Phases 4–5), and the breaking `/annotations/` layout goes **live to
 users** (needs a grace period). Ownership: annotations grace = **operations#83**;
 capacity = **operations#82**; date-gate + umbrella = **#1**; consumer file-path
 contracts = **#3**.
+
+> **Status — T-0 cutover executed 2026-06-19 (#19, build #86).** The first
+> new-pipeline bless published the tree to `current` + `release/2026-06-19` and
+> minted Zenodo DOIs (main `10.5281/zenodo.20943148`, products
+> `10.5281/zenodo.20941845`; see `docs/zenodo-archival.md`). The Track-B publish
+> was **additive** (overlay, no `--delete`) — `current/` now serves the old flat
+> files and the new `gaf/`·`gpi/` layout side by side, so the **Track C grace
+> period is active.** Track A gates were satisfied in practice by this run.
 
 ### Track A — Readiness gates (must be green before T‑0)
 - **Publish/bless tail built — the critical path** (Phases 4–5; operations#83
@@ -413,7 +425,8 @@ Picking up the new *release* (distinct from the annotations grace mechanism):
    **keeping `go-cams/index-json/`** (defer #12) so go-fastapi needs no config
    change at cutover; revisit later.
 3. **Bless trigger (#1)** — manual vs timed; intentionally open.
-4. **Downloads page link target (#396)** — stable `current/` vs rolling skyhook.
+4. **Downloads page link target (#396)** — **resolved 2026-06-19: `current`**
+   (canonical post-release; page moved in-site, gh.io#930).
 
 ## Cross-cutting tracking issues
 - #1 — assemble full pipeline / switchover timing

--- a/docs/zenodo-archival.md
+++ b/docs/zenodo-archival.md
@@ -132,4 +132,8 @@ Only **discard** a draft you are *not* going to publish (a pure throwaway test):
   in the Jenkinsfile.
 - **First production bless — DONE (2026-06-19).** main archive DOI
   `10.5281/zenodo.20943148`, secondary products `10.5281/zenodo.20941845`; published
-  via the rehearse → review → publish-draft flow.
+  via the rehearse → review → publish-draft flow. The main archive is ~1.3 GiB — an
+  order of magnitude below the old pipeline's ~16 GiB; the drop is the discontinued
+  all-UniProt mega-GAF (`filtered_goa_uniprot_all.gaf.gz`, ~10 GiB) + `annotations/archive/`
+  (~9 GiB), see `parity-and-products.md` — **not** missing content (ontology + all 171
+  species' annotations are intact).


### PR DESCRIPTION
The ops hand-off doc filed downloads + go-cam-browser under "Out of scope (separate / human)", even though `release-runbook.md`'s Definition of Done counts them — so a reader (the operations session) under-weights them. This replaces that section with a tracked **Downstream consumer updates** table giving each surface an action / owner / tracking ref.

Key correction: **go-stats is no longer a dangling post-publish step.** `release_stats/` (incl. `go-stats-summary.json` with the `release_date`, and `aggregated-go-stats-summaries.json`) is generated **in-pipeline** (Phase 2) and published with the tree; `geneontology.org/stats.html` fetches it dynamically (verified: the published summary carries `release_date: 2026-06-19`). The old SNS-triggered model is gone.

Also adds:
- the downloads **in-site** move (geneontology.github.io#930, pipeline-from-goa#396),
- the old-URL **CloudFront 301 forward** still owed by operations (**operations#86**),
- go-cam-browser per-release `data.json`, and the **conditional** npm publishes.

Verified live during the 2026-06-19 (#86) deploy: golr/amigo/api on the new release, downloads page + go-cam-browser data both deployed, go-stats summary current.

_— Posted by Claude Code agent on behalf of @kltm._