### PR TITLE
justfile: add downloads-regen recipe (trigger website downloads regen, #396)

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -304,13 +304,15 @@ Details / dependencies:
   internally with Minerva — not the pipeline's concern.)
 
 ## Phase 7 — Downstream app releases *(external / human)*
-- Downloads page: regenerate `downloads.html` in `geneontology.github.io` via
-  `scripts/update_downloads.py` (reads go-site `metadata/goex.yaml`, links to
-  skyhook annotations) → deploy via the website. Tracked at **pipeline#396**;
-  currently manual. **Stale-link bug:** the script's GAF links predate the #15
-  annotations restructure (`annotations/{code}.gaf.gz` /`{code}-uniprot.gaf.gz`)
-  and must move to `annotations/gaf/{code}-mod.gaf.gz` (~23 MOD orgs only) and
-  `annotations/gaf/{code}-uniprot.gaf.gz`; GPI currently links to EBI, not skyhook. 👤
+- Downloads page: **`just downloads-regen`** (this repo) fires the
+  `geneontology.github.io` `update-downloads.yaml` workflow, which regenerates the
+  by-organism page from go-site `metadata/goex.yaml` + `current.geneontology.org`
+  and opens a PR; review + **merge to deploy** (the merge triggers the Pages build).
+  The page is a website artifact served from `geneontology.org`, so it stays in
+  `geneontology.github.io`; the release process owns only the trigger. The old
+  stale-GAF-link bug is resolved — links now use the `annotations/gaf/`·`gpi/`
+  layout on `current` (geneontology.github.io#930). Tracked at **pipeline#396**
+  (+ geneontology.github.io#932, pipeline-from-goa#29). 👤
 - go-cam-browser "ping patrick": regenerate committed `public/data.json` →
   `data-release-YYYY-MM-DD` branch → merge → GitHub Pages auto-deploy. 👤
 - amigo / metadata **npm** packages. 👤

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -45,9 +45,10 @@ the phases below, not done-criteria.
      `go-data-product-release`, dated).
 2. **Downloads page regenerated and deployed to the main website.** This is a
    `geneontology.github.io` step (`scripts/update_downloads.py`, driven only by
-   go-site `metadata/goex.yaml`, linking to skyhook annotations), tracked at
-   **pipeline#396** — **not** a pipeline-from-goa product. Currently manual
-   ("does not yet auto-regenerate").
+   go-site `metadata/goex.yaml`, linking to **`current.geneontology.org`**
+   annotations — never skyhook), tracked at **pipeline#396** — **not** a
+   pipeline-from-goa product. Triggered per release via `just downloads-regen`
+   (see Phase 7).
 3. **Data products for external interfaces are in place, and any necessary
    service updates/restarts are done** for:
    - **amigo / golr**
@@ -415,7 +416,8 @@ Picking up the new *release* (distinct from the annotations grace mechanism):
    **keeping `go-cams/index-json/`** (defer #12) so go-fastapi needs no config
    change at cutover; revisit later.
 3. **Bless trigger (#1)** — manual vs timed; intentionally open.
-4. **Downloads page link target (#396)** — stable `current/` vs rolling skyhook.
+4. **Downloads page link target (#396)** — **resolved: `current/`.** Skyhook was
+   only a pre-release testing footing; the page always links to `current`.
 
 ## Cross-cutting tracking issues
 - #1 — assemble full pipeline / switchover timing

--- a/justfile
+++ b/justfile
@@ -102,3 +102,11 @@ verify:
     @echo "current index:"  ; curl -sS -o /dev/null -w "  %{http_code}  %{url_effective}\n" https://current.geneontology.org/index.html
     @echo "release catalog:"; curl -sS -o /dev/null -w "  %{http_code}  %{url_effective}\n" https://release.geneontology.org/index.html
     @echo "DOI file in tree:"; test -f {{doi_file}} && cat {{doi_file}} || echo "  (not written yet)"
+
+# Phase 7 (downstream): regenerate the public downloads page for this release (#396).
+# Fires the geneontology.github.io workflow, which regenerates the page from go-site
+# goex.yaml + current.geneontology.org and opens a PR -- review + merge it to deploy.
+# Needs `gh` (run from anywhere; no tree access required). Optional reason for the PR.
+downloads-regen reason='manual':
+    gh workflow run update-downloads.yaml --repo geneontology/geneontology.github.io -f reason="{{reason}}"
+    @echo "Triggered. Review + merge the PR to deploy: https://github.com/geneontology/geneontology.github.io/pulls"


### PR DESCRIPTION
Adds a `just downloads-regen` recipe (the **trigger half** of geneontology/pipeline#396) to the bless tail.

It fires the companion `update-downloads.yaml` workflow in `geneontology.github.io` (**geneontology/geneontology.github.io#932**), which regenerates the downloads page from go-site `goex.yaml` + `current.geneontology.org` and opens a PR to review + merge (the merge deploys).

This is the "semi-manual step, homed in the release process" for the downloads page: the **artifact** stays in the website repo (it's a `geneontology.org` page), while the **invocation** lives here in the release tooling. Run `just downloads-regen "release YYYY-MM-DD"` at publish time. Needs `gh`; no tree access required (runs from anywhere).

_— Posted by Claude Code agent on behalf of @kltm._
